### PR TITLE
Support map pod's /home dir to host node

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: v2
 description: Deploy a out of the box environment in k8s cluster for development and debug
 name: ubuntu-develop-env
-version: 1.0.0
+version: 1.0.1
 home: https://kungze.github.io/documents/
 sources:
   - https://github.com/kungze/ubuntu-develop-env

--- a/chart/templates/statefulset.yaml
+++ b/chart/templates/statefulset.yaml
@@ -55,14 +55,20 @@ spec:
                   env|grep KUBERNETES | xargs -I {} echo export {} >> /etc/profile
       serviceAccountName: {{ .Release.Name | quote }}
       {{- end }}
+  {{- if not (empty .Values.homeStorageClass) }}
   volumeClaimTemplates:
     - metadata:
         name: home-dir
       spec:
         accessModes: ["ReadWriteOnce"]
-        {{- if not (empty .Values.homeStorageClass) }}
         storageClassName: {{ .Values.homeStorageClass | quote }}
-        {{- end }}
         resources:
           requests:
             storage: {{ .Values.homeStorageSize }}
+  {{- else }}
+      volumes:
+        - name: home-dir
+          hostPath:
+            path: {{ printf "%s/%s/%s" .Values.hostConf.homeDirPath .Release.Namespace .Release.Name | quote }}
+            type: DirectoryOrCreate
+  {{- end }}


### PR DESCRIPTION
Previously, in order to persist the pod's /home, the chart need
claim a persistent volume. The patch provide an another solution: map
the pod's /home dir to host node.